### PR TITLE
Place header icons on right side

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,22 +5,29 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Luzzato</title>
   <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="pagina-inicial">
     <div class="antes-menu">FRETE <p class="txt"> GRÁTIS </p> Na compra de 2 itens ou mais</div>
   <header class="cabecalho">
     <img class="logo" src="https://sp-ao.shortpixel.ai/client/to_webp,q_glossy,ret_img,w_1000,h_300/https://luzzato.com.br/wp-content/uploads/2024/10/Sem-Titulo-1-1.png" alt="">
+    <input type="text" class="campo-busca" placeholder="Buscar...">
     <button class="menu-toggle" id="menu-toggle" aria-label="Abrir menu">
       &#9776;
     </button>
-    <nav>
-      <ul class="menu" id="menu">
-        <li><a href="#">Início</a></li>
-        <li><a href="#produtos">Produtos</a></li>
-        <li><a href="#contato">Contato</a></li>
-      </ul>
-    </nav>
+    <div class="icones">
+      <i class="fa-solid fa-user"></i>
+      <i class="fa-solid fa-heart"></i>
+      <i class="fa-solid fa-shopping-cart"></i>
+    </div>
   </header>
+  <nav class="menu-principal">
+    <ul class="menu" id="menu">
+      <li><a href="#">Início</a></li>
+      <li><a href="#produtos">Produtos</a></li>
+      <li><a href="#contato">Contato</a></li>
+    </ul>
+  </nav>
 
   <section class="banner-rotativo">
     <div class="slides fade">

--- a/style.css
+++ b/style.css
@@ -45,6 +45,35 @@
     width: 160px;
     height: 60px;
   }
+
+  .icones {
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+    margin-right: 1rem;
+  }
+
+
+  .campo-busca {
+    padding: 0.3rem 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    width: 300px;
+  }
+
+  .icones i {
+    font-size: 1.2rem;
+    color: #fff;
+    cursor: pointer;
+  }
+
+  .menu-principal {
+    background-color: #d93;
+    display: flex;
+    justify-content: center;
+    padding: 0.5rem 0;
+  }
+
   
   .menu {
     list-style: none;


### PR DESCRIPTION
## Summary
- moved the icon container after the menu toggle in `index.html`
- updated `.icones` margin so icons appear on the right

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687ae814d004832796b94833acea10a5